### PR TITLE
Fixes #135 - Fix rendering of buttons in header

### DIFF
--- a/upload/inc/plugins/isango.php
+++ b/upload/inc/plugins/isango.php
@@ -14,7 +14,7 @@ if (!defined("IN_MYBB")) {
 }
 
 $plugins->add_hook('global_start', 'isango_templates');
-$plugins->add_hook('global_start', 'isango_buttons');
+$plugins->add_hook('global_intermediate', 'isango_buttons');
 $plugins->add_hook('error', 'isango_buttons_nopermit');
 $plugins->add_hook('member_login', 'isango_bridge');
 $plugins->add_hook('usercp_menu', 'isango_ucpnav', 25);

--- a/upload/inc/plugins/isango.php
+++ b/upload/inc/plugins/isango.php
@@ -14,7 +14,7 @@ if (!defined("IN_MYBB")) {
 }
 
 $plugins->add_hook('global_start', 'isango_templates');
-$plugins->add_hook('global_end', 'isango_buttons');
+$plugins->add_hook('global_start', 'isango_buttons');
 $plugins->add_hook('error', 'isango_buttons_nopermit');
 $plugins->add_hook('member_login', 'isango_bridge');
 $plugins->add_hook('usercp_menu', 'isango_ucpnav', 25);


### PR DESCRIPTION
Use global_start instead of global_end  hook to render buttons in header.

Fixes #135 

**Thank you @lairdshaw for debugging and for your fix!**