### PR TITLE
Gitlab Support

### DIFF
--- a/upload/inc/plugins/isango/gitlab.ini
+++ b/upload/inc/plugins/isango/gitlab.ini
@@ -1,0 +1,15 @@
+[auth]
+url = "https://gitlab.com/oauth/authorize"
+params[scope] = "read_user"
+
+[token]
+url = "https://gitlab.com/oauth/token"
+
+[api]
+url = "https://gitlab.com/api/v4/user"
+
+[info]
+id = "{$u['id']}"
+name = "{$u['username']}"
+email = "{$u['email']}"
+avatar = "{$u['avatar_url']}"


### PR DESCRIPTION
Added GitLab Support.

- Missing button for `isango_gitlab`, didn't have much success making it look nice ha.

Credit to @lairdshaw for helping me figure it out.

Resolves #106 